### PR TITLE
fjern ubrukte felter og kast valideringsfeil

### DIFF
--- a/src/main/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsskjemaProdusent.kt
+++ b/src/main/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsskjemaProdusent.kt
@@ -3,7 +3,6 @@ package no.nav.permitteringsskjemaapi.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
-import no.nav.permitteringsskjemaapi.config.logger
 import no.nav.permitteringsskjemaapi.permittering.Permitteringsskjema
 import no.nav.permitteringsskjemaapi.permittering.SkjemaType
 import no.nav.permitteringsskjemaapi.permittering.Yrkeskategori
@@ -23,8 +22,6 @@ class PermitteringsskjemaProdusent(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     private val mapper: ObjectMapper,
 ) {
-
-    private val log = logger()
 
     fun sendTilKafkaTopic(permitteringsskjema: Permitteringsskjema) {
         val rapport = PermitteringsskjemaKafkaMelding(

--- a/src/main/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsskjemaProdusent.kt
+++ b/src/main/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsskjemaProdusent.kt
@@ -13,7 +13,6 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId.systemDefault
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -31,16 +30,10 @@ class PermitteringsskjemaProdusent(
         val rapport = PermitteringsskjemaKafkaMelding(
             antallBerorte = permitteringsskjema.antallBerørt,
             bedriftsnummer = permitteringsskjema.bedriftNr,
-            fritekst = permitteringsskjema.fritekst,
             id = permitteringsskjema.id,
-            kontaktEpost = permitteringsskjema.kontaktEpost,
-            kontaktNavn = permitteringsskjema.kontaktNavn,
-            kontaktTlf = permitteringsskjema.kontaktTlf,
             sendtInnTidspunkt = permitteringsskjema.sendtInnTidspunkt,
             sluttDato = permitteringsskjema.sluttDato,
             startDato = permitteringsskjema.startDato,
-            varsletAnsattDato = permitteringsskjema.sendtInnTidspunkt.let { LocalDate.ofInstant(it, systemDefault()) },
-            varsletNavDato = permitteringsskjema.sendtInnTidspunkt.let { LocalDate.ofInstant(it, systemDefault()) },
             type = permitteringsskjema.type,
             årsakskode = permitteringsskjema.årsakskode,
             årsakstekst = permitteringsskjema.årsakstekst,
@@ -51,7 +44,7 @@ class PermitteringsskjemaProdusent(
 
         val validationErrors = validateAgainstSchema(jsonEvent)
         if (validationErrors.isNotEmpty()) {
-            log.error("json validation failed: {}", validationErrors.joinToString())
+            throw Error("json validation failed: ${validationErrors.joinToString()}")
         }
 
         kafkaTemplate.send(
@@ -69,14 +62,8 @@ class PermitteringsskjemaProdusent(
         var bedriftsnummer: String,
         var sendtInnTidspunkt: Instant,
         var type: SkjemaType,
-        var kontaktNavn: String,
-        var kontaktTlf: String,
-        var kontaktEpost: String,
-        var varsletAnsattDato: LocalDate,
-        var varsletNavDato: LocalDate,
         var startDato: LocalDate,
         var sluttDato: LocalDate?,
-        var fritekst: String,
         var antallBerorte: Int,
         var årsakskode: Årsakskode,
         var årsakstekst: String?,

--- a/src/main/kotlin/no/nav/permitteringsskjemaapi/sletting/SletteService.kt
+++ b/src/main/kotlin/no/nav/permitteringsskjemaapi/sletting/SletteService.kt
@@ -43,24 +43,5 @@ class SletteService(
                 log.info("Slettet $deleted gamle rader fra journalforing")
             }
         }
-
-
-        // delete from legacy tables. remove this and drop the table when all data is gone
-        // note: all data has been migrated to permitteringsskjema_v2, but is kept for histoic value in case of bugs
-        jdbcTemplate.update(
-            """
-                with deleted as (
-                    delete from permitteringsskjema
-                    where sendt_inn_tidspunkt < ?
-                    returning id
-                )
-                delete from yrkeskategori where permitteringsskjema_id in (select id from deleted);
-            """) { ps ->
-            ps.setTimestamp(1, java.sql.Timestamp.from(oldestTimestamp))
-        }.let { deleted ->
-            if (deleted > 0) {
-                log.info("Slettet $deleted gamle rader fra permitteringsskjema med tilhørende yrkeskategorier")
-            }
-        }
     }
 }

--- a/src/main/resources/db/migration/V26__drop_permitteringsskjema.sql
+++ b/src/main/resources/db/migration/V26__drop_permitteringsskjema.sql
@@ -1,0 +1,2 @@
+drop table permitteringsskjema;
+drop table yrkeskategori;

--- a/src/main/resources/kafka-schema.json
+++ b/src/main/resources/kafka-schema.json
@@ -24,18 +24,6 @@
       "pattern": "[0-9]{9}",
       "description": "Orgnr. til underenhet. Valgt av bruker fra nedtrekksliste."
     },
-    "kontaktNavn": {
-      "type": "string",
-      "description": "Navnet bruker har oppgitt som kontaktperson."
-    },
-    "kontaktEpost": {
-      "type": "string",
-      "description": "Epost-adresse bruker har oppgitt for kontaktpersonen."
-    },
-    "kontaktTlf": {
-      "type": "string",
-      "description": "Telefonnummer bruker har oppgitt for kontaktpersonen."
-    },
     "sendtInnTidspunkt": {
       "type": "string",
       "description": "Timestamp fra backenden fra når bruker klikket på \"Send til NAV\". Eksempel: `2023-09-21T12:56:03.840448Z`."
@@ -85,18 +73,6 @@
       },
       "description": "Yrkene til de berørte. Valgt av bruker. Tilgjengelige valg hentet fra Janzz."
     },
-    "varsletAnsattDato": {
-      "type": "string",
-      "description": "Navnet på feltet beskriver ikke tidspunktet i feltet. Vanskelig å gi en klar beskrivelse av tidspunktet, men det er knyttet til brukers interaksjoner med skjemaet. Ikke bruk feltet."
-    },
-    "varsletNavDato": {
-      "type": "string",
-      "description": "Navnet på feltet beskriver ikke tidspunktet i feltet. Vanskelig å gi en klar beskrivelse av tidspunktet, men det er knyttet til brukers interaksjoner med skjemaet. Ikke bruk feltet."
-    },
-    "fritekst": {
-      "type": "string",
-      "description": "Ikke fritekst. Maskinelt genereret ut fra feltene \"årsakskode\" og \"yrkeskategorier\"."
-    },
     "årsakstekst": {
       "type": ["string", "null"],
       "description": "Tror feltet alltid mangler."
@@ -107,15 +83,9 @@
     "type",
     "antallBerorte",
     "bedriftsnummer",
-    "kontaktNavn",
-    "kontaktEpost",
-    "kontaktTlf",
     "sendtInnTidspunkt",
     "startDato",
     "årsakskode",
-    "yrkeskategorier",
-    "varsletAnsattDato",
-    "varsletNavDato",
-    "fritekst"
+    "yrkeskategorier"
   ]
 }

--- a/src/test/kotlin/no/nav/permitteringsskjemaapi/kafka/KafkaSchemaTests.kt
+++ b/src/test/kotlin/no/nav/permitteringsskjemaapi/kafka/KafkaSchemaTests.kt
@@ -82,17 +82,11 @@ class KafkaSchemaTests {
     private val eksempel1 = PermitteringsskjemaProdusent.PermitteringsskjemaKafkaMelding(
         antallBerorte = 10,
         bedriftsnummer = "123412341",
-        fritekst = "friiiiii",
         id = UUID.randomUUID(),
-        kontaktEpost = "lol@lol",
-        kontaktNavn = "dora",
-        kontaktTlf = "43214123",
         sendtInnTidspunkt = Instant.now(),
         sluttDato = LocalDate.now().plusDays(30),
         startDato = LocalDate.now(),
         type = SkjemaType.INNSKRENKNING_I_ARBEIDSTID,
-        varsletAnsattDato = LocalDate.now().minusDays(7),
-        varsletNavDato = LocalDate.now(),
         yrkeskategorier = listOf(
             Yrkeskategori(
                 konseptId = 42,

--- a/src/test/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsmeldingKafkaServiceTest.kt
+++ b/src/test/kotlin/no/nav/permitteringsskjemaapi/kafka/PermitteringsmeldingKafkaServiceTest.kt
@@ -1,0 +1,68 @@
+package no.nav.permitteringsskjemaapi.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import no.nav.permitteringsskjemaapi.permittering.Permitteringsskjema
+import no.nav.permitteringsskjemaapi.permittering.SkjemaType
+import no.nav.permitteringsskjemaapi.permittering.Yrkeskategori
+import no.nav.permitteringsskjemaapi.permittering.Årsakskode
+import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.kafka.core.KafkaTemplate
+import java.time.Instant
+import java.time.LocalDate
+import java.util.*
+import java.util.concurrent.CompletableFuture
+
+
+@SpringBootTest(properties = [
+    "spring.flyway.cleanDisabled=false",
+    "spring.flyway.validateOnMigrate=false"
+])
+@MockBean(MultiIssuerConfiguration::class)
+class PermitteringsskjemaProdusentTest {
+
+    @MockBean
+    lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var permitteringsskjemaProdusent: PermitteringsskjemaProdusent
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun senderTilKafka() {
+        val captor = ArgumentCaptor.forClass(ProducerRecord::class.java) as ArgumentCaptor<ProducerRecord<String, String>>
+        `when`(kafkaTemplate.send(captor.capture())).thenReturn(CompletableFuture.completedFuture(null))
+        permitteringsskjemaProdusent.sendTilKafkaTopic(
+            Permitteringsskjema(
+                id = UUID.randomUUID(),
+                antallBerørt = 1,
+                bedriftNavn = "hey",
+                bedriftNr = "1234567890",
+                kontaktEpost = "hey",
+                kontaktNavn = "hey",
+                kontaktTlf = "hey",
+                opprettetAv = "hey",
+                sendtInnTidspunkt = Instant.parse("2010-01-01T01:01:01Z"),
+                startDato = LocalDate.parse("2020-01-01"),
+                sluttDato = LocalDate.parse("2020-01-01"),
+                ukjentSluttDato = false,
+                type = SkjemaType.INNSKRENKNING_I_ARBEIDSTID,
+                yrkeskategorier = listOf(Yrkeskategori(1, "hey", "hey")),
+                årsakskode = Årsakskode.MANGEL_PÅ_ARBEID,
+            )
+        )
+
+        val json = captor.value.value()
+        Assertions.assertNotNull(json)
+    }
+}


### PR DESCRIPTION
PR inneholøder følgende endringer:
* dropper gammel permitteringsskjema tabell. Denne er ikke lenger i bruk
  * [x] all data er migrert fra permitteringsskjema til permitteringsskjema_v2, sanity check at all data er migrert. 
    ```
    select count(*) from permitteringsskjema
      where sendt_inn_tidspunkt is not null 
      and id not in (select id from permitteringsskjema_v2)
    => 0
    ```
* dropper gammel tabell for yrkeskategorier
* fjerner felt fra kafka melding som ikke brukes. 
  * Før merge:
    * [x] gi beskjed til konsument `dv-a-team` https://nav-it.slack.com/archives/C8XSXBF3P/p1702287653203179
      * https://nav-it.slack.com/archives/C8XSXBF3P/p1704192525022309
    * [x] gi beskjed til konsument `crm-plattform-team` https://nav-it.slack.com/archives/CMYSGB77B/p1702289175700239
      * https://nav-it.slack.com/archives/CMYSGB77B/p1704192708136619
      * [x] de ønsker beskjed ca 30 min før vi prodsetter.
* kaster feil ved melding som ikke er i henhold til json schema definisjon
    