### PR TITLE
rm organisasjoner v1

### DIFF
--- a/src/main/kotlin/no/nav/permitteringsskjemaapi/altinn/OrganisasjonerController.kt
+++ b/src/main/kotlin/no/nav/permitteringsskjemaapi/altinn/OrganisasjonerController.kt
@@ -9,9 +9,6 @@ class OrganisasjonerController(
     private val altinnService: AltinnService
 ) {
 
-    @GetMapping("/organisasjoner")
-    fun hentOrganisasjoner() = altinnService.hentOrganisasjoner()
-
     @GetMapping("/organisasjoner-v2")
     fun hentOrganisasjonerV2() = altinnService.hentAltinnTilganger().hierarki
 }

--- a/src/main/kotlin/no/nav/permitteringsskjemaapi/permittering/PermitteringsskjemaController.kt
+++ b/src/main/kotlin/no/nav/permitteringsskjemaapi/permittering/PermitteringsskjemaController.kt
@@ -69,7 +69,7 @@ class PermitteringsskjemaController(
     fun sendInn(@Valid @RequestBody skjema: PermitteringsskjemaV2DTO): PermitteringsskjemaV2DTO {
         val fnr = fnrExtractor.autentisertBruker()
 
-        if (altinnService.hentOrganisasjoner().none { it.organizationNumber == skjema.bedriftNr }) {
+        if (altinnService.hentAltinnTilganger().alleOrgNr.none { it == skjema.bedriftNr }) {
             throw IkkeTilgangException()
         }
 

--- a/src/test/kotlin/no/nav/permitteringsskjemaapi/altinn/AltinnServiceTest.kt
+++ b/src/test/kotlin/no/nav/permitteringsskjemaapi/altinn/AltinnServiceTest.kt
@@ -48,12 +48,10 @@ class AltinnServiceTest {
                 withSuccess(altinnTilgangerResponse, APPLICATION_JSON)
             )
 
-        val organisasjoner = altinnService.hentOrganisasjoner()
+        val tilganger = altinnService.hentAltinnTilganger()
 
-        assertTrue(organisasjoner.size == 2)
-
-        val parent = organisasjoner.first { it.organizationNumber == "810825472" }
-        val underenhet = organisasjoner.first { it.organizationNumber == "910825496" }
+        val parent = tilganger.hierarki.first { it.orgNr == "810825472" }
+        val underenhet = tilganger.hierarki.first().underenheter.first { it.orgNr == "910825496" }
 
         assertTrue(parent.name == "Arbeids- og Velferdsetaten")
         assertTrue(underenhet.name == "SLEMMESTAD OG STAVERN REGNSKAP")


### PR DESCRIPTION
all trafikk er over på v2. denne PR rydder bort gammelt endepunkt og kode

https://prometheus.prod-gcp.nav.cloud.nais.io/graph?g0.expr=sum(http_server_requests_seconds_count%7Bapp%3D%22permitteringsskjema-api%22%2C%20uri%3D~%22%2Forganisasjoner.*%22%7D)%20by%20(uri)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1w